### PR TITLE
Add compatibility for DigitalOcean Spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,6 @@ check-api-credentials-work: docker-build-quiet
 		--env COD_PASSWORD='$(COD_API_PASSWORD)' \
 		$(DOCKER_IMG_TAG) $(BIN_SH_PATH) -c "cd fetcher && npm run-script check-credentials" >/dev/null 2>&1 || (echo "COD credentials didnt work, please check them at https://my.callofduty.com/login" && exit 1)
 
-# https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility
 check-s3-bucket-exists:
 	$(AWS_CMD) s3api head-bucket --bucket $(AWS_S3_BUCKET_NAME) --endpoint-url $(AWS_S3_ENDPOINT) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt exist, create it first!" && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ endif
 
 AWS_CMD = docker run --rm --env AWS_ACCESS_KEY_ID='$(AWS_ACCESS_KEY_ID)' --env AWS_SECRET_ACCESS_KEY='$(AWS_SECRET_ACCESS_KEY)' amazon/aws-cli
 AWS_ECS_CMD = docker run --rm --env AWS_ACCESS_KEY_ID='$(AWS_ACCESS_KEY_ID)' --env AWS_SECRET_ACCESS_KEY='$(AWS_SECRET_ACCESS_KEY)' --env AWS_DEFAULT_REGION=$(AWS_REGION) amazon/aws-cli -- ecs
-AWS_S3_PUBLIC_URL = https://$(AWS_S3_BUCKET_NAME).s3.amazonaws.com/index.html
+AWS_S3_PUBLIC_URL = https://$(AWS_S3_BUCKET_NAME).$(HOST_REGION).$(HOST_PROVIDER)/index.html
+AWS_S3_ENDPOINT = https://$(HOST_REGION).$(HOST_PROVIDER)
 
 ifeq ($(OS),Windows_NT)
 # NOTE(jpr): see https://www.reddit.com/r/docker/comments/734arg/cant_figure_out_how_to_bash_into_docker_container/dnnz2uq/
@@ -29,6 +30,7 @@ docker-run: docker-build
 		--env AWS_ACCESS_KEY_ID='$(AWS_ACCESS_KEY_ID)' \
 		--env AWS_SECRET_ACCESS_KEY='$(AWS_SECRET_ACCESS_KEY)' \
 		--env S3_BUCKET_NAME='$(AWS_S3_BUCKET_NAME)' \
+		--env S3_ENDPOINT='$(AWS_S3_ENDPOINT)' \
 		--env COD_USERNAME='$(COD_API_USERNAME)' \
 		--env COD_PASSWORD='$(COD_API_PASSWORD)' \
 		$(DOCKER_IMG_TAG)
@@ -46,6 +48,11 @@ check-bootstrap: silent-by-default check-docker-is-installed check-players-json-
 	@echo You should be able to view your site at $(AWS_S3_PUBLIC_URL) after you run \`make docker-run\`
 
 ensure-bootstrap: silent-by-default check-docker-is-installed check-players-json-created ensure-api-credentials-set check-api-credentials-work ensure-aws-credentials-set check-aws-credentials-work ensure-s3-bucket-name-set ensure-s3-bucket-exists ensure-s3-bucket-is-website ensure-s3-bucket-has-public-policy
+	@echo Everything should be setup for bucket [$(AWS_S3_BUCKET_NAME)]
+	@echo You should be able to view your site at $(AWS_S3_PUBLIC_URL) after you run \`make docker-run\`
+
+# https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility
+do-ensure-bootstrap: silent-by-default check-docker-is-installed check-players-json-created ensure-api-credentials-set check-api-credentials-work ensure-aws-credentials-set ensure-s3-bucket-name-set ensure-s3-bucket-exists ensure-s3-bucket-has-public-policy
 	@echo Everything should be setup for bucket [$(AWS_S3_BUCKET_NAME)]
 	@echo You should be able to view your site at $(AWS_S3_PUBLIC_URL) after you run \`make docker-run\`
 
@@ -123,14 +130,15 @@ check-api-credentials-work: docker-build-quiet
 		--env COD_PASSWORD='$(COD_API_PASSWORD)' \
 		$(DOCKER_IMG_TAG) $(BIN_SH_PATH) -c "cd fetcher && npm run-script check-credentials" >/dev/null 2>&1 || (echo "COD credentials didnt work, please check them at https://my.callofduty.com/login" && exit 1)
 
+# https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility
 check-s3-bucket-exists:
-	$(AWS_CMD) s3api head-bucket --bucket $(AWS_S3_BUCKET_NAME) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt exist, create it first!" && exit 1)
+	$(AWS_CMD) s3api head-bucket --bucket $(AWS_S3_BUCKET_NAME) --endpoint-url $(AWS_S3_ENDPOINT) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt exist, create it first!" && exit 1)
 
 check-s3-bucket-is-website:
-	$(AWS_CMD) s3api get-bucket-website --bucket $(AWS_S3_BUCKET_NAME) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] is not an s3 website, enable the configuration!" && exit 1)
+	$(AWS_CMD) s3api get-bucket-website --bucket $(AWS_S3_BUCKET_NAME) --endpoint-url $(AWS_S3_ENDPOINT) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] is not an s3 website, enable the configuration!" && exit 1)
 
 check-s3-bucket-has-public-policy:
-	$(AWS_CMD) s3api get-bucket-policy --bucket $(AWS_S3_BUCKET_NAME) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt have a public policy, attach it first!" && exit 1)
+	$(AWS_CMD) s3api get-bucket-policy --bucket $(AWS_S3_BUCKET_NAME) --endpoint-url $(AWS_S3_ENDPOINT) >/dev/null || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt have a public policy, attach it first!" && exit 1)
 
 ensure-s3-bucket-exists:
 # NOTE(jpr): aws has different rules for us-east-1....
@@ -144,7 +152,7 @@ ensure-s3-bucket-is-website:
 	$(MAKE) check-s3-bucket-is-website >/dev/null 2>&1 || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] is not an s3 website, enabling the configuration.." && $(AWS_CMD) s3 website s3://$(AWS_S3_BUCKET_NAME) --index-document index.html)
 
 ensure-s3-bucket-has-public-policy:
-	$(MAKE) check-s3-bucket-has-public-policy >/dev/null 2>&1 || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt have a public policy, attaching.." && $(AWS_CMD) s3api put-bucket-policy --bucket $(AWS_S3_BUCKET_NAME) --policy '{ "Statement": [ { "Effect": "Allow", "Principal": "*", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::$(AWS_S3_BUCKET_NAME)/*" } ] }')
+	$(MAKE) check-s3-bucket-has-public-policy >/dev/null 2>&1 || (echo "Bucket [$(AWS_S3_BUCKET_NAME)] doesnt have a public policy, attaching.." && $(AWS_CMD) s3api --endpoint-url=$(AWS_S3_ENDPOINT) put-bucket-policy --bucket $(AWS_S3_BUCKET_NAME) --policy '{ "Statement": [ { "Effect": "Allow", "Principal": "*", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::$(AWS_S3_BUCKET_NAME)/*" } ] }')
 
 ensure-s3-bucket-name-set:
 ifndef AWS_S3_BUCKET_NAME

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ cp config/env.example config/env
 cp config/players.json.example config/players.json
 # ... fill in players.json ...
 
-make ensure-bootstrap && make-docker-run
+make ensure-bootstrap && make docker-run
+# If you are running on DigitalOcean ...
+make do-ensure-bootstrap && make docker-run
 ```
 
 and then to update with newer data in the future, just run this:

--- a/config/env.example
+++ b/config/env.example
@@ -15,7 +15,7 @@ AWS_S3_BUCKET_NAME =
 
 # This is your hosting provider. Either amazonaws.com or digitaloceanspaces.com
 HOST_PROVIDER = amazonaws.com
-# Leave this as s3 for AWS.  For DigitalOcean use $(AWS_REGION)
+# For AWS use s3. For DigitalOcean use $(AWS_REGION)
 HOST_REGION = s3
 # HOST_REGION = $(AWS_REGION)
 

--- a/config/env.example
+++ b/config/env.example
@@ -13,6 +13,12 @@ AWS_REGION =
 # NOTE(jpr): this has to be globally unique, and it will be part of the public url that gets used
 AWS_S3_BUCKET_NAME =
 
+# This is your hosting provider. Either amazonaws.com or digitaloceanspaces.com
+HOST_PROVIDER = amazonaws.com
+# Leave this as s3 for AWS.  For DigitalOcean use $(AWS_REGION)
+HOST_REGION = s3
+# HOST_REGION = $(AWS_REGION)
+
 # These are your activision account credentials from my.callofduty.com
 COD_API_USERNAME =
 COD_API_PASSWORD =

--- a/config/env.example
+++ b/config/env.example
@@ -20,9 +20,7 @@ HOST_REGION = s3
 # HOST_REGION = $(AWS_REGION)
 
 # These are your activision account credentials from my.callofduty.com
-COD_API_USERNAME =
-COD_API_PASSWORD =
-
+COD_API_SSO =
 
 ################################################################################
 # Optional

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -19,11 +19,15 @@ if [ -z "${S3_BUCKET_NAME:-}" ]; then
   die 'Must set envvar [S3_BUCKET_NAME]'
 fi
 
+if [ -z "${S3_ENDPOINT:-}" ]; then
+  die 'Must set envvar [S3_ENDPOINT]'
+fi
+
 main() {
   pushd "${sourcedir}" > /dev/null
 
   echo 'uploading to s3...'
-  aws s3 sync --delete . s3://"${S3_BUCKET_NAME}"/
+  aws s3 sync --delete . s3://"${S3_BUCKET_NAME}"/ --endpoint="${S3_ENDPOINT}"
 
   echo
   echo 'Done!'

--- a/fetcher/check_api_credentials.ts
+++ b/fetcher/check_api_credentials.ts
@@ -1,7 +1,6 @@
 const API = require('call-of-duty-api')();
 
-const USERNAME = process.env.COD_USERNAME;
-const PASSWORD = process.env.COD_PASSWORD;
+const SSO = process.env.COD_SSO;
 
 // DO WORK SON
 
@@ -10,21 +9,17 @@ const PASSWORD = process.env.COD_PASSWORD;
  */
 
 (async () => {
-  if (!USERNAME) {
-    console.error('Must set envvar [COD_USERNAME]');
-    process.exit(1);
-  }
-
-  if (!PASSWORD) {
-    console.error('Must set envvar [COD_PASSWORD]');
+  if (!SSO) {
+    console.error('Must set envvar [COD_SSO]');
     process.exit(1);
   }
 
   try {
-    await API.login(USERNAME, PASSWORD);
+    await API.loginWithSSO(SSO);
     console.log('Credentials valid.');
   } catch (err) {
     console.log('--------------------------------------------------------------------------------');
+    console.log(SSO);
     console.error('ERROR:');
     console.error(err);
     process.exit(1);

--- a/fetcher/check_api_credentials.ts
+++ b/fetcher/check_api_credentials.ts
@@ -19,7 +19,6 @@ const SSO = process.env.COD_SSO;
     console.log('Credentials valid.');
   } catch (err) {
     console.log('--------------------------------------------------------------------------------');
-    console.log(SSO);
     console.error('ERROR:');
     console.error(err);
     process.exit(1);

--- a/fetcher/fetch_matches.ts
+++ b/fetcher/fetch_matches.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs';
 const API = require('call-of-duty-api')();
 
-const USERNAME = process.env.COD_USERNAME;
-const PASSWORD = process.env.COD_PASSWORD;
+const SSO = process.env.COD_SSO;
 const COD_DATADIR = process.env.COD_DATADIR;
 const OUTDIR = `${COD_DATADIR}/fetcher/output`;
 const RATE_LIMIT_FILE = `${COD_DATADIR}/fetcher/rate_limit_until.json`;
@@ -84,7 +83,7 @@ function deleteRateLimitInfo() {
 
 async function loginIfNeeded() {
   if (!API.isLoggedIn()) {
-    await API.login(USERNAME, PASSWORD);
+    await API.loginWithSSO(SSO);
   }
 }
 
@@ -295,13 +294,8 @@ async function main(mappings: PlayerMapping[]): Promise<Result<any>> {
     process.exit(1);
   }
 
-  if (!USERNAME) {
-    console.error('Must set envvar [COD_USERNAME]');
-    process.exit(1);
-  }
-
-  if (!PASSWORD) {
-    console.error('Must set envvar [COD_PASSWORD]');
+  if (!SSO) {
+    console.error('Must set envvar [COD_SSO]');
     process.exit(1);
   }
 

--- a/fetcher/package-lock.json
+++ b/fetcher/package-lock.json
@@ -1,21 +1,68 @@
 {
   "name": "fetcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
     "@types/node": {
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
+    },
+    "@types/puppeteer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
+      "integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axios-rate-limit": {
@@ -23,20 +70,578 @@
       "resolved": "https://registry.npmjs.org/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz",
       "integrity": "sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw=="
     },
-    "call-of-duty-api": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/call-of-duty-api/-/call-of-duty-api-1.2.16.tgz",
-      "integrity": "sha512-7rAkKBrKLBx3RabCyhQ3ExaP/wCPw0eOzNw5/Di3QAN80HPGrIsqAYxc4A2px6BeW8q3sYrwW8mIjK0Lh4wlsg==",
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
-        "axios": "^0.20.0",
-        "axios-rate-limit": "^1.2.1",
-        "uniqid": "^5.2.0"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "call-of-duty-api": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/call-of-duty-api/-/call-of-duty-api-2.1.2.tgz",
+      "integrity": "sha512-3eYbkZcZAK5OUTQKmoShKMXq/Wd7q1eSAQJfX0kttNGOt6g7HI++YvwocebBFN7V2tAuVblQrb5EtNz40HEFdg==",
+      "requires": {
+        "axios": "^0.21.1",
+        "axios-rate-limit": "^1.3.0",
+        "puppeteer": "^10.1.0",
+        "puppeteer-extra": "^3.1.18",
+        "puppeteer-extra-plugin-recaptcha": "^3.4.0",
+        "puppeteer-extra-plugin-stealth": "^2.7.8",
+        "uniqid": "^5.3.0"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+      "requires": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "devtools-protocol": {
+      "version": "0.0.901419",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
+      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "puppeteer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.2.0.tgz",
+      "integrity": "sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==",
+      "requires": {
+        "debug": "4.3.1",
+        "devtools-protocol": "0.0.901419",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "node-fetch": "2.6.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.1",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.0.0",
+        "unbzip2-stream": "1.3.3",
+        "ws": "7.4.6"
+      }
+    },
+    "puppeteer-extra": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.1.18.tgz",
+      "integrity": "sha512-mGQyAnxaGcZomx7NVC4wgAkZl0MLTdE/GIfwRSbLJ9L4yIxPg9uEA3yiLBe+x09tjhTGEtv8KDef8Bl53RXgiA==",
+      "requires": {
+        "@types/debug": "^4.1.0",
+        "@types/puppeteer": "5.4.3",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "puppeteer-extra-plugin": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.1.9.tgz",
+      "integrity": "sha512-LYKj+3wGsnBzwEIpTertyOkzjcTHJn96FDSFXQ4Oo38CFFRw1qRBAJPPtAaMVjuVDqATeNd/RpP4n5jbxeX90g==",
+      "requires": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      }
+    },
+    "puppeteer-extra-plugin-recaptcha": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-recaptcha/-/puppeteer-extra-plugin-recaptcha-3.4.0.tgz",
+      "integrity": "sha512-JgQfIgkZNt5GKekQBzYLCxy0rUGYunscJ5paqI7tYY9xSNDI3AL5zKuKWaSENG2g54TNgCt85+wUl+fZZWHytw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.2",
+        "puppeteer-extra-plugin": "^3.1.9"
+      }
+    },
+    "puppeteer-extra-plugin-stealth": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.7.8.tgz",
+      "integrity": "sha512-Zhm/WY/BAk9VGdZR5OVpiwfGn2NoAzEb0hdu3/PGRryfenn8Dtoai8aUa8GzFPExWL+yGPsztswupH+3TV3M2A==",
+      "requires": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.1.9",
+        "puppeteer-extra-plugin-user-preferences": "^2.2.12"
+      }
+    },
+    "puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.2.12.tgz",
+      "integrity": "sha512-+RTNevJLswyh/RfQ+c46otTtE9eABKv8KkLGHcz1jpnVH/iX2wHu7VkXA5Y9pKBaLYDt83BON8wCowy5Eh/KWA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.1.0",
+        "puppeteer-extra-plugin": "^3.1.9"
+      }
+    },
+    "puppeteer-extra-plugin-user-preferences": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.2.12.tgz",
+      "integrity": "sha512-y4YOykpYHq0t8qnRyuSL6sIDIRKgdlKkIIFdRbfZx3cg7nxeVLkHgEz3v/Ob0U/lvzlSrr4xvHhG+KcVWH7BXA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.1.9",
+        "puppeteer-extra-plugin-user-data-dir": "^2.2.12"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "requires": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "tar-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "typescript": {
       "version": "3.9.2",
@@ -44,10 +649,48 @@
       "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
+    "unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
     "uniqid": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
-      "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.4.0.tgz",
+      "integrity": "sha512-38JRbJ4Fj94VmnC7G/J/5n5SC7Ab46OM5iNtSstB/ko3l1b5g7ALt4qzHFgGciFkyiRNtDXtLNb+VsxtMSE77A=="
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     }
   }
 }

--- a/fetcher/package.json
+++ b/fetcher/package.json
@@ -1,10 +1,10 @@
 {
   "name": "fetcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "call-of-duty-api": "^1.2.16"
+    "call-of-duty-api": "^2.1.2"
   },
   "devDependencies": {
     "@types/node": "^14.0.13",

--- a/fetcher/query_player.ts
+++ b/fetcher/query_player.ts
@@ -1,7 +1,6 @@
 const API = require('call-of-duty-api')();
 
-const USERNAME = process.env.COD_USERNAME;
-const PASSWORD = process.env.COD_PASSWORD;
+const SSO = process.env.COD_SSO;
 
 // Typings
 
@@ -13,7 +12,7 @@ type Result<T> = ResultOK<T> | ResultError;
 
 async function loginIfNeeded() {
   if (!API.isLoggedIn()) {
-    await API.login(USERNAME, PASSWORD);
+    await API.loginWithSSO(SSO);
   }
 }
 
@@ -78,13 +77,8 @@ async function lookupUnoId(platform: string, username: string) {
  */
 
 (async () => {
-  if (!USERNAME) {
-    console.error('Must set envvar [COD_USERNAME]');
-    process.exit(1);
-  }
-
-  if (!PASSWORD) {
-    console.error('Must set envvar [COD_PASSWORD]');
+  if (!SSO) {
+    console.error('Must set envvar [COD_SSO]');
     process.exit(1);
   }
 


### PR DESCRIPTION
This add compatibility for hosting on DigitalOcean.

There are two new variables introduced to the config/env file` (HOST_REGION, HOST_PROVIDER)`. I made the default values in the config/env.example for AWS.  There are certain AWS features that DigitalOcean Spaces is not compatible with, so I made a separate `do-ensure-bootstrap` with the incompatible pieces removed.

I do not currently have an AWS account so please test these changes work for you.  They should, but please verify.